### PR TITLE
maint/allow_more_compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
+cmake_minimum_required(VERSION 3.0.2)
 cmake_policy(SET CMP0048 NEW)
 project(bolgenos-ng
 	VERSION 0.0.2)
-cmake_minimum_required(VERSION 3.0.2)
 
 set(kernel_headers_dir "include/")
 include_directories(${kernel_headers_dir})

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -7,28 +7,23 @@ set(dep_flags "-ffreestanding")
 set(warn_flags "-Wall -Wextra -Werror -Wstrict-aliasing")
 
 
-#--- BEGIN OF CROSS COMPILER DETECTION ---
-
 set(target_hw "i686")
 set(target_format "elf")
 set(target_c "gcc")
 set(target_c_compiler_name "${target_hw}-${target_format}-${target_c}")
 
-find_program(found_c_compiler ${target_c_compiler_name})
+find_program(found_c_compiler NAMES ${target_c_compiler_name})
 
-if (${found_c_compiler})
+if (found_c_compiler)
 	set(CMAKE_C_COMPILER "${found_c_compiler}")
 else()
-	message(WARNING "Cross-compiler for target platform is not found!"
+	message(WARNING "${target_c_compiler_name} is not found!"
 		" Default compiler (${CMAKE_C_COMPILER}) will be used.")
 endif()
 
 message(STATUS
 	"Toolchain information\n"
-	"C Compiler = ${CMAKE_C_COMPILER}\n"
-)
-
-#--- END OF CROSS COMPILER DETECTION ---
+	"C Compiler = ${CMAKE_C_COMPILER}")
 
 
 # FIXME: looks like a crap

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -6,6 +6,31 @@ set(output_format_flags "-m32 -march=i686")
 set(dep_flags "-ffreestanding")
 set(warn_flags "-Wall -Wextra -Werror -Wstrict-aliasing")
 
+
+#--- BEGIN OF CROSS COMPILER DETECTION ---
+
+set(target_hw "i686")
+set(target_format "elf")
+set(target_c "gcc")
+set(target_c_compiler_name "${target_hw}-${target_format}-${target_c}")
+
+find_program(found_c_compiler ${target_c_compiler_name})
+
+if (${found_c_compiler})
+	set(CMAKE_C_COMPILER "${found_c_compiler}")
+else()
+	message(WARNING "Cross-compiler for target platform is not found!"
+		" Default compiler (${CMAKE_C_COMPILER}) will be used.")
+endif()
+
+message(STATUS
+	"Toolchain information\n"
+	"C Compiler = ${CMAKE_C_COMPILER}\n"
+)
+
+#--- END OF CROSS COMPILER DETECTION ---
+
+
 # FIXME: looks like a crap
 set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 set(CMAKE_EXE_LINKER_FLAGS "")

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -1,16 +1,15 @@
 project(bolgneos-ng ASM-ATT C)
 
-# FIXME: will not work on different machines
-set(CMAKE_CXX_COMPILER i686-elf-g++)
-set(CMAKE_C_COMPILER i686-elf-gcc)
-set(CMAKE_ASM-ATT_COMPILER i686-elf-gcc)
-
 add_definitions(-std=gnu99)
+
+set(output_format_flags "-m32 -march=i686")
+set(dep_flags "-ffreestanding")
+set(warn_flags "-Wall -Wextra -Werror -Wstrict-aliasing")
 
 # FIXME: looks like a crap
 set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 set(CMAKE_EXE_LINKER_FLAGS "")
-set(CMAKE_C_FLAGS "-ffreestanding -Wall -Wextra -Werror -Wstrict-aliasing")
+set(CMAKE_C_FLAGS "${warn_flags} ${output_format_flags} ${dep_flags}")
 set(CMAKE_ASM-ATT_COMPILER "${CMAKE_C_COMPILER}")
 set(CMAKE_ASM-ATT_FLAGS ${CMAKE_C_FLAGS})
 set(CMAKE_ASM-ATT_COMPILE_OBJECT ${CMAKE_C_COMPILE_OBJECT})
@@ -21,7 +20,7 @@ include_directories(${CONFIG_INCLUDE_DIRS})
 
 # Variable $kernel_start_file should keep source file that will be included
 # in kernel of any configuration and can be compiled very fast.
-# This file can be used for forcing relinking and other dirty hacks.
+# This file is used for forcing relinking of resulting object.
 set(kernel_start_file "${CMAKE_CURRENT_SOURCE_DIR}/start.sx")
 
 set(kernel_sources ${kernel_start_file}


### PR DESCRIPTION
build: allow using usual compiler

Removed requirement to use i686-elf-gcc. For other compilers output format is set for 32-bit arch.

Todo:
#24

Activity: #23
Status: closed
