### PR TITLE
Feature/use cmake toolchain files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.0.2)
 cmake_policy(SET CMP0048 NEW)
 project(bolgenos-ng
-	VERSION 0.0.4)
+	VERSION 0.0.4
+	LANGUAGES NONE)
 
 set(kernel_headers_dir "include/")
 include_directories(${kernel_headers_dir})

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -1,54 +1,47 @@
-project(kernel ASM-ATT C)
+project(kernel
+	LANGUAGES ASM-ATT C CXX)
+
+message(STATUS "Compiling BOLGENOS-NG using toolchain: "
+	"${CMAKE_TOOLCHAIN_FILE}")
+
+set(target_binary_format "elf")
+set(target_processor "i686")
+
+if (NOT ("${CMAKE_SYSTEM_NAME}" STREQUAL "${target_binary_format}"))
+	message(FATAL_ERROR "BOLGENOS-NG can be compiled only in "
+		" '${target_binary_format}'"
+		" but '${CMAKE_SYSTEM_NAME}' is supplied")
+endif()
+
+
+if (NOT ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "${target_processor}")
+	message(FATAL_ERROR "BOLGENOS-NG supports only ${target_processor} "
+		"but ${CMAKE_SYSTEM_PROCESSOR} is supplied")
+endif()
+
 
 set(cstd_flags "-std=gnu99")
 set(cxxstd_flags "-std=gnu++11")
 
-set(output_format_flags "-m32 -march=i686")
-set(dep_flags "-ffreestanding")
 set(warn_flags "-Wall -Wextra -Werror -Wstrict-aliasing -Winline")
 set(warn_flags_cxx "-Weffc++")
-set(cxx_features_flags "-fno-rtti -fno-exceptions")
 
 
-set(target_hw "i686")
-set(target_format "elf")
-set(target_c "gcc")
-set(target_cxx "g++")
-set(target_c_compiler_name "${target_hw}-${target_format}-${target_c}")
-set(target_cxx_compiler_name "${target_hw}-${target_format}-${target_cxx}")
 
-find_program(found_c_compiler NAMES ${target_c_compiler_name})
-find_program(found_cxx_compiler NAMES ${target_cxx_compiler_name})
+unset(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS)
+unset(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS)
+unset(CMAKE_EXE_LINKER_FLAGS)
 
-if (found_c_compiler)
-	set(CMAKE_C_COMPILER "${found_c_compiler}")
-else()
-	message(WARNING "${target_c_compiler_name} is not found!"
-		" Default compiler (${CMAKE_C_COMPILER}) will be used.")
-endif()
-
-if (found_cxx_compiler)
-	set(CMAKE_CXX_COMPILER "${found_cxx_compiler}")
-else()
-	message(WARNING "${target_cxx_compiler_name} is not found!"
-		" Default compiler (${CMAKE_CXX_COMPILER}) will be used.")
-endif()
-
-message(STATUS
-	"Toolchain information\n"
-	"C Compiler = ${CMAKE_C_COMPILER}\n"
-	"CXX Compiler = ${CMAKE_CXX_COMPILER}")
-
-
-# FIXME: looks like a crap
-set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
-set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
-set(CMAKE_EXE_LINKER_FLAGS "")
-set(CMAKE_C_FLAGS "${warn_flags} ${output_format_flags} ${dep_flags} ${cstd_flags}")
-set(CMAKE_CXX_FLAGS "${warn_flags} ${warn_flags_cxx} ${output_format_flags} ${dep_flags} ${cxxstd_flags} ${cxx_features_flags}")
-set(CMAKE_ASM-ATT_COMPILER "${CMAKE_C_COMPILER}")
-set(CMAKE_ASM-ATT_FLAGS ${CMAKE_C_FLAGS})
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${warn_flags} ${cstd_flags}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${warn_flags} ${warn_flags_cxx} ${cxxstd_flags}")
 set(CMAKE_ASM-ATT_COMPILE_OBJECT ${CMAKE_C_COMPILE_OBJECT})
+
+message(STATUS "Toolchain information:")
+foreach(compiler CMAKE_C_COMPILER CMAKE_C_COMPILER CMAKE_ASM-ATT_COMPILER)
+	message(STATUS "${compiler} = ${${compiler}}")
+endforeach()
+
+message(STATUS "Compiler is configured. Adding targets..")
 
 set(kernel_binary "kernel.bin")
 
@@ -66,14 +59,12 @@ set(m4_output_dir "${CMAKE_CURRENT_BINARY_DIR}/m4_generated")
 file(MAKE_DIRECTORY ${m4_output_dir})
 
 
-set(m4_generated_files "")
-
 foreach(m4_file ${m4_input_files})
 	get_filename_component(in_basename ${m4_file} NAME)
 	string(REGEX REPLACE ".m4" "" out_basename ${in_basename})
 	set(out_file "${m4_output_dir}/${out_basename}")
 	set(m4_generated_files "${out_file}" ${m4_generated_file})
-	message("adding target ${out_file}")
+	message(STATUS "Found m4-generated file \"${out_file}\"")
 	add_custom_command(OUTPUT "${out_file}"
 		COMMAND m4 -P "${m4_file}" > "${out_file}"
 		COMMENT m4 -P "${m4_file}" > "${out_file}"
@@ -152,12 +143,11 @@ set_source_files_properties(${kernel_start_file} PROPERTIES
 	LANGUAGE "ASM-ATT")
 
 
-message("gen_files = ${m4_generated_files}")
-message("config_h = ${config_h}")
+message(STATUS "Build configuration: ${config_h}")
 
 
 
-message("kernel_sources = ${kernel_sources}")
+message(STATUS "List of kernel source files: ${kernel_sources}")
 add_executable(${kernel_binary}
 	${kernel_headers}
 	${kernel_sources}

--- a/samples/toolchains/README.md
+++ b/samples/toolchains/README.md
@@ -1,0 +1,5 @@
+The `toolchains` directory
+--------------------------
+
+This directory contains cmake toolchains files for my hosts. These toolchains
+should not be used as is. They are just examples and backup.

--- a/samples/toolchains/toolchain.cmake
+++ b/samples/toolchains/toolchain.cmake
@@ -1,0 +1,41 @@
+set(CMAKE_SYSTEM_NAME elf)
+set(CMAKE_SYSTEM_PROCESSOR i686)
+set(sdk_path "/home/dabogdanov/cross-host/i686-elf")
+set(toolchain_path "${sdk_path}/toolchain")
+set(toolchain_bin_path "${toolchain_path}/bin")
+
+set(toolchain_debug FALSE)
+
+macro(verbose_set VAR VALUE)
+	set("${VAR}" "${VALUE}")
+	if(${toolchain_debug})
+		message(STATUS "exporting (toochain ${triple}): "
+			"${VAR} = ${${VAR}}")
+	endif()
+endmacro(verbose_set)
+
+# yep, it is not an actually triple
+verbose_set(triple "${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
+
+set(output_format_flags "-m32 -march=i686")
+
+# -ffeestanding implies -fno-builtin
+set(dependencies_flags "-ffreestanding -nostdlib")
+
+set(asm_c_cxx_common_flags "${output_format_flags} ${dependencies_flags}")
+
+set(cxx_unsupported_features "-fno-rtti -fno-exceptions")
+set(cxx_specific "${cxx_unsupported_features}")
+
+verbose_set(CMAKE_C_COMPILER "${toolchain_bin_path}/${triple}-gcc")
+verbose_set(CMAKE_C_COMPILER_FORCED TRUE)
+verbose_set(CMAKE_C_FLAGS "${asm_c_cxx_common_flags}")
+
+verbose_set(CMAKE_CXX_COMPILER "${toolchain_bin_path}/${triple}-g++")
+verbose_set(CMAKE_CXX_COMPILER_FORCED TRUE)
+verbose_set(CMAKE_CXX_FLAGS "${asm_c_cxx_common_flags} ${cxx_specific}")
+
+verbose_set(CMAKE_ASM-ATT_COMPILER "${CMAKE_C_COMPILER}")
+verbose_set(CMAKE_ASM-ATT_COMPILER_FORCED TRUE)
+verbose_set(CMAKE_ASM-ATT_FLAGS "${asm_c_cxx_common_flags}")
+


### PR DESCRIPTION
build: add toolchains support

buildsystem is reworked in order to support toolchains instead of hardcoded compiler.

activity: #24
status: closed
